### PR TITLE
Migration to wicket/wiquery 1.5.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,11 +15,10 @@
 	<name>WQPlot</name>
 	<description>Wicket/WiQuery-JqPlot binding</description>
 	<properties>
-		<wicket.version>1.4.15</wicket.version>
+		<wicket.version>1.5.3</wicket.version>
 		<jetty.version>6.1.25</jetty.version>
 		<slf4j.version>1.6.1</slf4j.version>
-		<jackson.version>1.6.1</jackson.version>
-		<wiquery.version>1.2-SNAPSHOT</wiquery.version>
+		<wiquery.version>1.5.3</wiquery.version>
 	</properties>
 
 	<url>https://github.com/hielkehoeve/wiquery-jqplot/wiki</url>
@@ -84,23 +83,18 @@
 		<!-- WICKET DEPENDENCIES -->
 		<dependency>
 			<groupId>org.apache.wicket</groupId>
-			<artifactId>wicket</artifactId>
+			<artifactId>wicket-core</artifactId>
 			<version>${wicket.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.odlabs.wiquery</groupId>
-			<artifactId>wiquery</artifactId>
+			<artifactId>wiquery-core</artifactId>
 			<version>${wiquery.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.codehaus.jackson</groupId>
-			<artifactId>jackson-core-asl</artifactId>
-			<version>${jackson.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.codehaus.jackson</groupId>
-			<artifactId>jackson-mapper-asl</artifactId>
-			<version>${jackson.version}</version>
+			<groupId>org.odlabs.wiquery</groupId>
+			<artifactId>wiquery-jquery-ui</artifactId>
+			<version>${wiquery.version}</version>
 		</dependency>
 		<!-- LOGGING DEPENDENCIES - LOG4J -->
 		<dependency>
@@ -219,7 +213,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-eclipse-plugin</artifactId>
-				<version>2.9-SNAPSHOT</version>
+				<version>2.8</version>
 				<inherited>true</inherited>
 				<configuration>
 					<downloadSources>true</downloadSources>
@@ -230,19 +224,6 @@
 				<groupId>org.mortbay.jetty</groupId>
 				<artifactId>maven-jetty-plugin</artifactId>
 				<version>${jetty.version}</version>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-gpg-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>sign-artifacts</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>sign</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/main/java/nl/topicus/wqplot/components/JQPlotExcanvasJavaScriptResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/JQPlotExcanvasJavaScriptResourceReference.java
@@ -1,6 +1,6 @@
 package nl.topicus.wqplot.components;
 
-import org.odlabs.wiquery.core.commons.WiQueryJavaScriptResourceReference;
+import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
 
 /**
  * Special javascript for when the User Agent is Internet Explorer.

--- a/src/main/java/nl/topicus/wqplot/components/JQPlotJavaScriptResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/JQPlotJavaScriptResourceReference.java
@@ -1,6 +1,6 @@
 package nl.topicus.wqplot.components;
 
-import org.odlabs.wiquery.core.commons.WiQueryJavaScriptResourceReference;
+import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
 
 public class JQPlotJavaScriptResourceReference extends WiQueryJavaScriptResourceReference
 {

--- a/src/main/java/nl/topicus/wqplot/components/JQPlotStyleSheetResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/JQPlotStyleSheetResourceReference.java
@@ -1,6 +1,6 @@
 package nl.topicus.wqplot.components;
 
-import org.odlabs.wiquery.core.commons.WiQueryStyleSheetResourceReference;
+import org.odlabs.wiquery.core.resources.WiQueryStyleSheetResourceReference;
 
 public class JQPlotStyleSheetResourceReference extends WiQueryStyleSheetResourceReference
 {

--- a/src/main/java/nl/topicus/wqplot/components/plugins/IPlugin.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/IPlugin.java
@@ -2,7 +2,7 @@ package nl.topicus.wqplot.components.plugins;
 
 import java.io.Serializable;
 
-import org.odlabs.wiquery.core.commons.WiQueryJavaScriptResourceReference;
+import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
 
 /**
  * @author Ernesto Reinaldo Barreiro

--- a/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotBarRendererResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotBarRendererResourceReference.java
@@ -1,6 +1,6 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.commons.WiQueryJavaScriptResourceReference;
+import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
 
 public class JQPlotBarRendererResourceReference extends WiQueryJavaScriptResourceReference
 {

--- a/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotBezierCurveRendererResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotBezierCurveRendererResourceReference.java
@@ -1,6 +1,6 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.commons.WiQueryJavaScriptResourceReference;
+import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
 
 public class JQPlotBezierCurveRendererResourceReference extends WiQueryJavaScriptResourceReference
 {

--- a/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotBlockRendererResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotBlockRendererResourceReference.java
@@ -1,6 +1,6 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.commons.WiQueryJavaScriptResourceReference;
+import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
 
 public class JQPlotBlockRendererResourceReference extends WiQueryJavaScriptResourceReference
 {

--- a/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotBubbleRendererResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotBubbleRendererResourceReference.java
@@ -1,6 +1,6 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.commons.WiQueryJavaScriptResourceReference;
+import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
 
 public class JQPlotBubbleRendererResourceReference extends WiQueryJavaScriptResourceReference
 {

--- a/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotCanvasAxisLabelRendererResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotCanvasAxisLabelRendererResourceReference.java
@@ -1,6 +1,6 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.commons.WiQueryJavaScriptResourceReference;
+import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
 
 public class JQPlotCanvasAxisLabelRendererResourceReference extends
 		WiQueryJavaScriptResourceReference

--- a/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotCanvasAxisTickRendererResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotCanvasAxisTickRendererResourceReference.java
@@ -1,6 +1,6 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.commons.WiQueryJavaScriptResourceReference;
+import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
 
 public class JQPlotCanvasAxisTickRendererResourceReference extends
 		WiQueryJavaScriptResourceReference

--- a/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotCanvasTextRendererResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotCanvasTextRendererResourceReference.java
@@ -1,6 +1,6 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.commons.WiQueryJavaScriptResourceReference;
+import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
 
 public class JQPlotCanvasTextRendererResourceReference extends WiQueryJavaScriptResourceReference
 {

--- a/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotCategoryAxisRendererResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotCategoryAxisRendererResourceReference.java
@@ -1,6 +1,6 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.commons.WiQueryJavaScriptResourceReference;
+import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
 
 public class JQPlotCategoryAxisRendererResourceReference extends WiQueryJavaScriptResourceReference
 {

--- a/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotCursorResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotCursorResourceReference.java
@@ -1,6 +1,6 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.commons.WiQueryJavaScriptResourceReference;
+import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
 
 public class JQPlotCursorResourceReference extends WiQueryJavaScriptResourceReference
 {

--- a/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotDateAxisRendererResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotDateAxisRendererResourceReference.java
@@ -1,6 +1,6 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.commons.WiQueryJavaScriptResourceReference;
+import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
 
 public class JQPlotDateAxisRendererResourceReference extends WiQueryJavaScriptResourceReference
 {

--- a/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotEnhancedLegendRendererResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotEnhancedLegendRendererResourceReference.java
@@ -1,6 +1,6 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.commons.WiQueryJavaScriptResourceReference;
+import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
 
 public class JQPlotEnhancedLegendRendererResourceReference extends
 		WiQueryJavaScriptResourceReference

--- a/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotHighlighterResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotHighlighterResourceReference.java
@@ -1,6 +1,6 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.commons.WiQueryJavaScriptResourceReference;
+import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
 
 public class JQPlotHighlighterResourceReference extends WiQueryJavaScriptResourceReference
 {

--- a/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotLogAxisRendererResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotLogAxisRendererResourceReference.java
@@ -1,6 +1,6 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.commons.WiQueryJavaScriptResourceReference;
+import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
 
 public class JQPlotLogAxisRendererResourceReference extends WiQueryJavaScriptResourceReference
 {

--- a/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotPieRendererResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotPieRendererResourceReference.java
@@ -1,6 +1,6 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.commons.WiQueryJavaScriptResourceReference;
+import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
 
 public class JQPlotPieRendererResourceReference extends WiQueryJavaScriptResourceReference
 {

--- a/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotPointLabelsResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotPointLabelsResourceReference.java
@@ -1,6 +1,6 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.commons.WiQueryJavaScriptResourceReference;
+import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
 
 public class JQPlotPointLabelsResourceReference extends WiQueryJavaScriptResourceReference
 {

--- a/src/main/java/nl/topicus/wqplot/components/plugins/Plugin.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/Plugin.java
@@ -1,6 +1,6 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.commons.WiQueryJavaScriptResourceReference;
+import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
 
 /**
  * @author Ernesto Reinaldo Barreiro

--- a/src/main/java/nl/topicus/wqplot/components/plugins/Renderer.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/Renderer.java
@@ -1,6 +1,6 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.commons.WiQueryJavaScriptResourceReference;
+import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
 
 /**
  * @author Ernesto Reinaldo Barreiro

--- a/src/test/java/nl/topicus/wqplot/web/WicketApplication.java
+++ b/src/test/java/nl/topicus/wqplot/web/WicketApplication.java
@@ -25,7 +25,8 @@ public class WicketApplication extends WebApplication
 		super.init();
 
 		getMarkupSettings().setStripWicketTags(true);
-		getSharedResources().putClassAlias(Application.class, "application");
+		//getSharedResources().putClassAlias(Application.class, "application");
+		
 		getResourceSettings().setResourcePollFrequency(Duration.ONE_SECOND);
 
 		getRequestLoggerSettings().setRequestLoggerEnabled(true);
@@ -40,6 +41,6 @@ public class WicketApplication extends WebApplication
 
 	public boolean isDevelopment()
 	{
-		return Application.DEVELOPMENT.equals(getConfigurationType());
+		return Application.CONFIGURATION.equals(getConfigurationType());
 	}
 }


### PR DESCRIPTION
Changed the IWQueryPlugin imports to use the wiquery paths.
JQPlot now user renderHead(IHeaderResponse) instead of contribute(WiQueryResourceManager).
Jackson dependencies are removed from the pom since they now are included in Wiquery and it created a version mismatch.
