### PR TITLE
Wicket 6 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,16 +11,16 @@
 	<groupId>nl.topicus</groupId>
 	<artifactId>wqplot</artifactId>
 	<packaging>jar</packaging>
-	<version>1.5-SNAPSHOT</version>
+	<version>1.6-SNAPSHOT</version>
 	<name>WQPlot</name>
 	<description>Wicket/WiQuery-JqPlot binding</description>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<wicket.version>1.5-SNAPSHOT</wicket.version>
-		<wiquery.version>1.5-SNAPSHOT</wiquery.version>
+		<wicket.version>6.6.0</wicket.version>
+		<wiquery.version>6.6.0</wiquery.version>
 		<slf4j.version>[1.6,1.6.10]</slf4j.version>
-		<junit.version>4.10</junit.version>
+		<junit.version>4.11</junit.version>
 		<jetty.version>6.1.26</jetty.version>
 
 		<maven-buildnumber-plugin.version>1.0</maven-buildnumber-plugin.version>

--- a/src/main/java/nl/topicus/wqplot/components/JQPlot.java
+++ b/src/main/java/nl/topicus/wqplot/components/JQPlot.java
@@ -109,7 +109,8 @@ public class JQPlot extends WebMarkupContainer implements IPluginResolver
 		}
 
 		ObjectMapper mapper = new ObjectMapper();
-		mapper.getSerializationConfig().setSerializationInclusion(Inclusion.NON_NULL);
+		mapper.setSerializationConfig(mapper.getSerializationConfig().withSerializationInclusion(
+			Inclusion.NON_NULL));
 		String optionsStr = "{}";
 		String plotDataStr = "[]";
 		try

--- a/src/main/java/nl/topicus/wqplot/components/JQPlot.java
+++ b/src/main/java/nl/topicus/wqplot/components/JQPlot.java
@@ -18,21 +18,21 @@ import nl.topicus.wqplot.data.Series;
 import nl.topicus.wqplot.options.PlotOptions;
 import nl.topicus.wqplot.options.PluginReferenceSerializer;
 
-import org.apache.wicket.markup.html.IHeaderResponse;
+import org.apache.wicket.markup.head.CssHeaderItem;
+import org.apache.wicket.markup.head.IHeaderResponse;
+import org.apache.wicket.markup.head.JavaScriptHeaderItem;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.protocol.http.WebSession;
 import org.apache.wicket.protocol.http.request.WebClientInfo;
-import org.apache.wicket.request.ClientInfo;
 import org.codehaus.jackson.JsonGenerationException;
 import org.codehaus.jackson.map.JsonMappingException;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.map.annotate.JsonSerialize;
 import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
-import org.odlabs.wiquery.core.IWiQueryPlugin;
 import org.odlabs.wiquery.core.javascript.JsStatement;
 
-public class JQPlot extends WebMarkupContainer implements IWiQueryPlugin, IPluginResolver
+public class JQPlot extends WebMarkupContainer implements IPluginResolver
 {
 	private static final long serialVersionUID = 1L;
 
@@ -76,38 +76,70 @@ public class JQPlot extends WebMarkupContainer implements IWiQueryPlugin, IPlugi
 	}
 
 	@Override
-	public void renderHead(IHeaderResponse headerResponse)
+	public void renderHead(org.apache.wicket.markup.head.IHeaderResponse response)
 	{
-		ClientInfo info = WebSession.get().getClientInfo();
+		WebClientInfo info = WebSession.get().getClientInfo();
 
-		if (info instanceof WebClientInfo)
+		/**
+		 * only IE 9 supports canvas natively.
+		 */
+		if (info.getProperties().isBrowserInternetExplorer()
+			&& info.getProperties().getBrowserVersionMajor() < 9)
 		{
-			/**
-			 * only IE 9 supports canvas natively.
-			 */
-			WebClientInfo webinfo = (WebClientInfo) info;
-			if (webinfo.getProperties().isBrowserInternetExplorer()
-				&& webinfo.getProperties().getBrowserVersionMajor() < 9)
-				// wiQueryResourceManager.addJavaScriptResource(JQPlotExcanvasJavaScriptResourceReference.get());
-				headerResponse.renderJavaScriptReference(JQPlotExcanvasJavaScriptResourceReference
-					.get());
+			// wiQueryResourceManager.addJavaScriptResource(JQPlotExcanvasJavaScriptResourceReference.get());
+			response.render(JavaScriptHeaderItem
+				.forReference(JQPlotExcanvasJavaScriptResourceReference.get()));
 		}
 
 		// wiQueryResourceManager.addJavaScriptResource(JQPlotJavaScriptResourceReference.get());
 		// wiQueryResourceManager.addCssResource(JQPlotStyleSheetResourceReference.get());
 		// wiQueryResourceManager.addJavaScriptResource(JQPlotCanvasTextRendererResourceReference.get());
-		headerResponse.renderJavaScriptReference(JQPlotJavaScriptResourceReference.get());
-		headerResponse.renderCSSReference(JQPlotStyleSheetResourceReference.get());
-		headerResponse.renderJavaScriptReference(JQPlotCanvasTextRendererResourceReference.get());
+		response.render(JavaScriptHeaderItem.forReference(JQPlotJavaScriptResourceReference.get()));
+		response.render(CssHeaderItem.forReference(JQPlotStyleSheetResourceReference.get()));
+		response.render(JavaScriptHeaderItem.forReference(JQPlotCanvasTextRendererResourceReference
+			.get()));
 
 		try
 		{
-			addPlugins(headerResponse);
+			addPlugins(response);
 		}
 		catch (IllegalAccessException e)
 		{
 			throw new RuntimeException(e);
 		}
+
+		ObjectMapper mapper = new ObjectMapper();
+		mapper.getSerializationConfig().setSerializationInclusion(Inclusion.NON_NULL);
+		String optionsStr = "{}";
+		String plotDataStr = "[]";
+		try
+		{
+			optionsStr = mapper.writeValueAsString(options);
+			plotDataStr = mapper.writeValueAsString(getModelObject());
+		}
+		catch (JsonGenerationException e)
+		{
+			e.printStackTrace();
+		}
+		catch (JsonMappingException e)
+		{
+			e.printStackTrace();
+		}
+		catch (IOException e)
+		{
+			e.printStackTrace();
+		}
+
+		JsStatement jsStatement =
+			new JsStatement().append("$.jqplot.config.catchErrors = " + isCatchErrors() + ";\n");
+		jsStatement.append("var " + getMarkupId() + " = $.jqplot('" + getMarkupId() + "', "
+			+ plotDataStr + ", " + optionsStr + ");\n");
+
+		for (String statement : afterRenderStatements)
+			jsStatement.append(statement);
+
+		response.render(JavaScriptHeaderItem.forScript(jsStatement.render(),
+			String.format("plot-%s", getMarkupId())));
 	}
 
 	private void addPlugins(IHeaderResponse headerResponse) throws IllegalAccessException
@@ -154,8 +186,8 @@ public class JQPlot extends WebMarkupContainer implements IWiQueryPlugin, IPlugi
 		if (plugins.containsKey(plugin))
 		{
 			// wiQueryResourceManager.addJavaScriptResource(getPlugin(plugin).getJavaScriptResourceReference());
-			headerResponse.renderJavaScriptReference(getPlugin(plugin)
-				.getJavaScriptResourceReference());
+			headerResponse.render(JavaScriptHeaderItem.forReference(getPlugin(plugin)
+				.getJavaScriptResourceReference()));
 			return;
 		}
 
@@ -165,7 +197,8 @@ public class JQPlot extends WebMarkupContainer implements IWiQueryPlugin, IPlugi
 			if (iPlugin != null)
 			{
 				// wiQueryResourceManager.addJavaScriptResource(iPlugin.getJavaScriptResourceReference());
-				headerResponse.renderJavaScriptReference(iPlugin.getJavaScriptResourceReference());
+				headerResponse.render(JavaScriptHeaderItem.forReference(iPlugin
+					.getJavaScriptResourceReference()));
 				return;
 			}
 		}
@@ -205,40 +238,5 @@ public class JQPlot extends WebMarkupContainer implements IWiQueryPlugin, IPlugi
 	public IPlugin getPlugin(String name)
 	{
 		return plugins.get(name);
-	}
-
-	@Override
-	public JsStatement statement()
-	{
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.getSerializationConfig().setSerializationInclusion(Inclusion.NON_NULL);
-		String optionsStr = "{}";
-		String plotDataStr = "[]";
-		try
-		{
-			optionsStr = mapper.writeValueAsString(options);
-			plotDataStr = mapper.writeValueAsString(getModelObject());
-		}
-		catch (JsonGenerationException e)
-		{
-			e.printStackTrace();
-		}
-		catch (JsonMappingException e)
-		{
-			e.printStackTrace();
-		}
-		catch (IOException e)
-		{
-			e.printStackTrace();
-		}
-		JsStatement jsStatement =
-			new JsStatement().append("$.jqplot.config.catchErrors = " + isCatchErrors() + ";\n");
-		jsStatement.append("var " + getMarkupId() + " = $.jqplot('" + getMarkupId() + "', "
-			+ plotDataStr + ", " + optionsStr + ");\n");
-
-		for (String statement : afterRenderStatements)
-			jsStatement.append(statement);
-
-		return jsStatement;
 	}
 }

--- a/src/main/java/nl/topicus/wqplot/components/JQPlot.java
+++ b/src/main/java/nl/topicus/wqplot/components/JQPlot.java
@@ -75,6 +75,11 @@ public class JQPlot extends WebMarkupContainer implements IPluginResolver
 		return (Collection< ? extends Series< ? , ? , ? >>) getDefaultModelObject();
 	}
 
+	public String getJQueryBinding()
+	{
+		return "$(document).ready(";
+	}
+
 	@Override
 	public void renderHead(org.apache.wicket.markup.head.IHeaderResponse response)
 	{
@@ -139,7 +144,8 @@ public class JQPlot extends WebMarkupContainer implements IPluginResolver
 		for (String statement : afterRenderStatements)
 			jsStatement.append(statement);
 
-		response.render(JavaScriptHeaderItem.forScript(jsStatement.render(),
+		response.render(JavaScriptHeaderItem.forScript(
+			String.format("%s function() {\n\t%s\n});", getJQueryBinding(), jsStatement.render()),
 			String.format("plot-%s", getMarkupId())));
 	}
 

--- a/src/main/java/nl/topicus/wqplot/components/JQPlotExcanvasJavaScriptResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/JQPlotExcanvasJavaScriptResourceReference.java
@@ -1,13 +1,13 @@
 package nl.topicus.wqplot.components;
 
-import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
+import org.apache.wicket.request.resource.JavaScriptResourceReference;
 
 /**
  * Special javascript for when the User Agent is Internet Explorer.
  * 
  * @author hielkehoeve
  */
-public class JQPlotExcanvasJavaScriptResourceReference extends WiQueryJavaScriptResourceReference
+public class JQPlotExcanvasJavaScriptResourceReference extends JavaScriptResourceReference
 {
 	private static final long serialVersionUID = -4771815414204892357L;
 

--- a/src/main/java/nl/topicus/wqplot/components/JQPlotJavaScriptResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/JQPlotJavaScriptResourceReference.java
@@ -1,8 +1,8 @@
 package nl.topicus.wqplot.components;
 
-import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
+import org.apache.wicket.request.resource.JavaScriptResourceReference;
 
-public class JQPlotJavaScriptResourceReference extends WiQueryJavaScriptResourceReference
+public class JQPlotJavaScriptResourceReference extends JavaScriptResourceReference
 {
 	private static final long serialVersionUID = -4771815414204892357L;
 

--- a/src/main/java/nl/topicus/wqplot/components/JQPlotStyleSheetResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/JQPlotStyleSheetResourceReference.java
@@ -1,8 +1,8 @@
 package nl.topicus.wqplot.components;
 
-import org.odlabs.wiquery.core.resources.WiQueryStyleSheetResourceReference;
+import org.apache.wicket.request.resource.CssResourceReference;
 
-public class JQPlotStyleSheetResourceReference extends WiQueryStyleSheetResourceReference
+public class JQPlotStyleSheetResourceReference extends CssResourceReference
 {
 	private static final long serialVersionUID = -4771815414204892357L;
 

--- a/src/main/java/nl/topicus/wqplot/components/plugins/IPlugin.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/IPlugin.java
@@ -2,7 +2,7 @@ package nl.topicus.wqplot.components.plugins;
 
 import java.io.Serializable;
 
-import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
+import org.apache.wicket.request.resource.JavaScriptResourceReference;
 
 /**
  * @author Ernesto Reinaldo Barreiro
@@ -18,6 +18,6 @@ public interface IPlugin extends Serializable
 	/**
 	 * The resource reference for the JavaScript file implementing the plugin.
 	 */
-	WiQueryJavaScriptResourceReference getJavaScriptResourceReference();
+	JavaScriptResourceReference getJavaScriptResourceReference();
 
 }

--- a/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotBarRendererResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotBarRendererResourceReference.java
@@ -1,8 +1,8 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
+import org.apache.wicket.request.resource.JavaScriptResourceReference;
 
-public class JQPlotBarRendererResourceReference extends WiQueryJavaScriptResourceReference
+public class JQPlotBarRendererResourceReference extends JavaScriptResourceReference
 {
 	private static final long serialVersionUID = -4771815414204892357L;
 

--- a/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotBezierCurveRendererResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotBezierCurveRendererResourceReference.java
@@ -1,8 +1,8 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
+import org.apache.wicket.request.resource.JavaScriptResourceReference;
 
-public class JQPlotBezierCurveRendererResourceReference extends WiQueryJavaScriptResourceReference
+public class JQPlotBezierCurveRendererResourceReference extends JavaScriptResourceReference
 {
 	private static final long serialVersionUID = -4771815414204892357L;
 

--- a/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotBlockRendererResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotBlockRendererResourceReference.java
@@ -1,8 +1,8 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
+import org.apache.wicket.request.resource.JavaScriptResourceReference;
 
-public class JQPlotBlockRendererResourceReference extends WiQueryJavaScriptResourceReference
+public class JQPlotBlockRendererResourceReference extends JavaScriptResourceReference
 {
 	private static final long serialVersionUID = -4771815414204892357L;
 

--- a/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotBubbleRendererResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotBubbleRendererResourceReference.java
@@ -1,8 +1,8 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
+import org.apache.wicket.request.resource.JavaScriptResourceReference;
 
-public class JQPlotBubbleRendererResourceReference extends WiQueryJavaScriptResourceReference
+public class JQPlotBubbleRendererResourceReference extends JavaScriptResourceReference
 {
 	private static final long serialVersionUID = -4771815414204892357L;
 

--- a/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotCanvasAxisLabelRendererResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotCanvasAxisLabelRendererResourceReference.java
@@ -1,9 +1,9 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
+import org.apache.wicket.request.resource.JavaScriptResourceReference;
 
 public class JQPlotCanvasAxisLabelRendererResourceReference extends
-		WiQueryJavaScriptResourceReference
+		JavaScriptResourceReference
 {
 	private static final long serialVersionUID = -4771815414204892357L;
 

--- a/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotCanvasAxisTickRendererResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotCanvasAxisTickRendererResourceReference.java
@@ -1,9 +1,9 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
+import org.apache.wicket.request.resource.JavaScriptResourceReference;
 
 public class JQPlotCanvasAxisTickRendererResourceReference extends
-		WiQueryJavaScriptResourceReference
+		JavaScriptResourceReference
 {
 	private static final long serialVersionUID = -4771815414204892357L;
 

--- a/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotCanvasTextRendererResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotCanvasTextRendererResourceReference.java
@@ -1,8 +1,8 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
+import org.apache.wicket.request.resource.JavaScriptResourceReference;
 
-public class JQPlotCanvasTextRendererResourceReference extends WiQueryJavaScriptResourceReference
+public class JQPlotCanvasTextRendererResourceReference extends JavaScriptResourceReference
 {
 	private static final long serialVersionUID = -4771815414204892357L;
 

--- a/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotCategoryAxisRendererResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotCategoryAxisRendererResourceReference.java
@@ -1,8 +1,8 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
+import org.apache.wicket.request.resource.JavaScriptResourceReference;
 
-public class JQPlotCategoryAxisRendererResourceReference extends WiQueryJavaScriptResourceReference
+public class JQPlotCategoryAxisRendererResourceReference extends JavaScriptResourceReference
 {
 	private static final long serialVersionUID = -4771815414204892357L;
 

--- a/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotCursorResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotCursorResourceReference.java
@@ -1,8 +1,8 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
+import org.apache.wicket.request.resource.JavaScriptResourceReference;
 
-public class JQPlotCursorResourceReference extends WiQueryJavaScriptResourceReference
+public class JQPlotCursorResourceReference extends JavaScriptResourceReference
 {
 	private static final long serialVersionUID = -4771815414204892357L;
 

--- a/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotDateAxisRendererResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotDateAxisRendererResourceReference.java
@@ -1,8 +1,8 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
+import org.apache.wicket.request.resource.JavaScriptResourceReference;
 
-public class JQPlotDateAxisRendererResourceReference extends WiQueryJavaScriptResourceReference
+public class JQPlotDateAxisRendererResourceReference extends JavaScriptResourceReference
 {
 	private static final long serialVersionUID = -4771815414204892357L;
 

--- a/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotEnhancedLegendRendererResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotEnhancedLegendRendererResourceReference.java
@@ -1,9 +1,9 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
+import org.apache.wicket.request.resource.JavaScriptResourceReference;
 
 public class JQPlotEnhancedLegendRendererResourceReference extends
-		WiQueryJavaScriptResourceReference
+		JavaScriptResourceReference
 {
 	private static final long serialVersionUID = -4771815414204892357L;
 

--- a/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotHighlighterResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotHighlighterResourceReference.java
@@ -1,8 +1,8 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
+import org.apache.wicket.request.resource.JavaScriptResourceReference;
 
-public class JQPlotHighlighterResourceReference extends WiQueryJavaScriptResourceReference
+public class JQPlotHighlighterResourceReference extends JavaScriptResourceReference
 {
 	private static final long serialVersionUID = -4771815414204892357L;
 

--- a/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotLogAxisRendererResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotLogAxisRendererResourceReference.java
@@ -1,8 +1,8 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
+import org.apache.wicket.request.resource.JavaScriptResourceReference;
 
-public class JQPlotLogAxisRendererResourceReference extends WiQueryJavaScriptResourceReference
+public class JQPlotLogAxisRendererResourceReference extends JavaScriptResourceReference
 {
 	private static final long serialVersionUID = -4771815414204892357L;
 

--- a/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotPieRendererResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotPieRendererResourceReference.java
@@ -1,8 +1,8 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
+import org.apache.wicket.request.resource.JavaScriptResourceReference;
 
-public class JQPlotPieRendererResourceReference extends WiQueryJavaScriptResourceReference
+public class JQPlotPieRendererResourceReference extends JavaScriptResourceReference
 {
 	private static final long serialVersionUID = -4771815414204892357L;
 

--- a/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotPointLabelsResourceReference.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/JQPlotPointLabelsResourceReference.java
@@ -1,8 +1,8 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
+import org.apache.wicket.request.resource.JavaScriptResourceReference;
 
-public class JQPlotPointLabelsResourceReference extends WiQueryJavaScriptResourceReference
+public class JQPlotPointLabelsResourceReference extends JavaScriptResourceReference
 {
 	private static final long serialVersionUID = -4771815414204892357L;
 

--- a/src/main/java/nl/topicus/wqplot/components/plugins/Plugin.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/Plugin.java
@@ -1,6 +1,6 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
+import org.apache.wicket.request.resource.JavaScriptResourceReference;
 
 /**
  * @author Ernesto Reinaldo Barreiro
@@ -12,9 +12,9 @@ public class Plugin implements IPlugin
 
 	private String name;
 
-	private WiQueryJavaScriptResourceReference javaScriptResourceReference;
+	private JavaScriptResourceReference javaScriptResourceReference;
 
-	protected Plugin(String name, WiQueryJavaScriptResourceReference javaScriptResourceReference)
+	protected Plugin(String name, JavaScriptResourceReference javaScriptResourceReference)
 	{
 		this.name = name;
 		this.javaScriptResourceReference = javaScriptResourceReference;
@@ -27,7 +27,7 @@ public class Plugin implements IPlugin
 	}
 
 	@Override
-	public WiQueryJavaScriptResourceReference getJavaScriptResourceReference()
+	public JavaScriptResourceReference getJavaScriptResourceReference()
 	{
 		return javaScriptResourceReference;
 	}

--- a/src/main/java/nl/topicus/wqplot/components/plugins/Renderer.java
+++ b/src/main/java/nl/topicus/wqplot/components/plugins/Renderer.java
@@ -1,6 +1,6 @@
 package nl.topicus.wqplot.components.plugins;
 
-import org.odlabs.wiquery.core.resources.WiQueryJavaScriptResourceReference;
+import org.apache.wicket.request.resource.JavaScriptResourceReference;
 
 /**
  * @author Ernesto Reinaldo Barreiro
@@ -9,7 +9,7 @@ public class Renderer extends Plugin implements IRenderer
 {
 	private static final long serialVersionUID = 1L;
 
-	protected Renderer(String name, WiQueryJavaScriptResourceReference javaScriptResourceReference)
+	protected Renderer(String name, JavaScriptResourceReference javaScriptResourceReference)
 	{
 		super(name, javaScriptResourceReference);
 	}

--- a/src/main/java/nl/topicus/wqplot/options/PluginReferenceSerializer.java
+++ b/src/main/java/nl/topicus/wqplot/options/PluginReferenceSerializer.java
@@ -7,7 +7,7 @@ import org.codehaus.jackson.JsonGenerationException;
 import org.codehaus.jackson.JsonGenerator;
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.map.SerializerProvider;
-import org.codehaus.jackson.map.ser.SerializerBase;
+import org.codehaus.jackson.map.ser.std.SerializerBase;
 
 public class PluginReferenceSerializer extends SerializerBase<Object>
 {

--- a/src/test/java/nl/topicus/wqplot/web/pages/examples/ZoomTestPage.java
+++ b/src/test/java/nl/topicus/wqplot/web/pages/examples/ZoomTestPage.java
@@ -88,7 +88,7 @@ public class ZoomTestPage extends WebPage
 		chart1O.setTitle("Google, Inc.");
 
 		Button button = new Button("button1");
-		button.add(new AttributeModifier("onclick", true, new Model<String>(chart1.getMarkupId()
+		button.add(AttributeModifier.replace("onclick", new Model<String>(chart1.getMarkupId()
 			+ ".resetZoom()")));
 		add(button);
 

--- a/src/test/java/nl/topicus/wqplot/web/pages/examples/dist/DateAxisTestPage.java
+++ b/src/test/java/nl/topicus/wqplot/web/pages/examples/dist/DateAxisTestPage.java
@@ -23,6 +23,8 @@ import org.apache.wicket.model.util.ListModel;
 public class DateAxisTestPage extends WebPage
 {
 
+	private static final long serialVersionUID = 1L;
+
 	/**
 	 * 
 	 */


### PR DESCRIPTION
I've upgraded the POM to Wicket and WiQuery versions 6.6.0, and adapted the code to make it compatible, and after that removed all compiler warnings. After testing it with an application I found out the plot was executed before the document was loaded, so I bound the plot code to document.ready(), changeable by subclasses (to support JQuery Mobile, for instance).
